### PR TITLE
Update spec_helper.rb to Include stat_calculator.rb and Create Basic Spec for Initialization

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'rspec' 
+
+gem 'pry'
+
+# gem "rails"
+
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.3)
+    diff-lcs (1.5.1)
+    method_source (1.1.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+
+PLATFORMS
+  arm64-darwin-24
+
+DEPENDENCIES
+  pry
+  rspec
+
+BUNDLED WITH
+   2.4.10

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
+#spec/spec_helper.rb
 # require 'simplecov'; SimpleCov.start
+
 require 'pry'
 require 'csv'
 require 'rspec'
 require './lib/stat_tracker'
-require './lib/game_teams'
+require './lib/stat_calculator'

--- a/spec/stat_calculator_spec.rb
+++ b/spec/stat_calculator_spec.rb
@@ -1,6 +1,5 @@
 # spec/stat_calculator_spec.rb
-require 'rspec'
-require_relative '../lib/stat_calculator'
+require'spec_helper'
 
 RSpec.describe StatCalculator do
   it 'exists' do


### PR DESCRIPTION
In this pull request, I’ve made updates specifically to `spec_helper.rb` and `stat_calculator_spec.rb`:

**Changes Made:**
- `spec_helper.rb`: Added require './lib/stat_calculator' to ensure that the StatCalculator class is available across all tests that rely on spec_helper.
- `stat_calculator_spec.rb`: Set up the basic structure and added an initialization test to confirm that StatCalculator can be instantiated correctly.