### PR TITLE
Feature/stat cal accuracy statistics

### DIFF
--- a/lib/stat_calculator.rb
+++ b/lib/stat_calculator.rb
@@ -36,6 +36,12 @@ class StatCalculator
     @teams.count
   end
 
+  def most_accurate_team(season)
+  end
+
+  def least_accurate_team(season)
+  end
+
   def game_ids_in_season(season)
     #filter games to get games for the specified season
     game_ids = []
@@ -59,5 +65,34 @@ class StatCalculator
     end
     season_game_teams 
   end
+
+  def teams_shot_ratios_by_season(season)
+    #accumulate total shots and goals for each game in that season
+    game_teams = game_teams_in_season(season)
+    stats = {}
+    game_teams.each do |game_team|
+      team_id = game_team.team_id
+      ratio = 0 
+      #calculate accuracy ratio (goals/shots)
+      if game_team.shots != 0
+        ratio = game_team.goals.to_f / game_team.shots.to_f
+      end
+      if stats[team_id].nil? 
+        stats[team_id] = []
+      end
+      stats[team_id] << ratio
+    end
+    averages = {}
+    stats.each do |team_id, ratios|
+      average = 0 
+      if ratios.length != 0
+        average = ratios.sum.to_f / ratios.length
+      end
+      averages[team_id] = average
+    end
+    averages
+  end
+
+
 
 end

--- a/lib/stat_calculator.rb
+++ b/lib/stat_calculator.rb
@@ -37,6 +37,24 @@ class StatCalculator
   end
 
   def most_accurate_team(season)
+    #return name of the Team with the best ratio of shots to goals for the given season
+    accuracy_by_team = teams_shot_ratios_by_season(season)
+    best_team = nil
+    best_average = 0
+
+    #find team with the highest accuracy
+    accuracy_by_team.each do |team_id, average|
+      if average > best_average 
+        best_average = average
+        best_team = team_id
+      end
+    end
+
+    #find team name by best_team ID
+    team = teams.find { |t| t.team_id.to_i == best_team.to_i }
+
+    # Return the team name or nil if not found
+    team ? team.team_name : nil  
   end
 
   def least_accurate_team(season)

--- a/lib/stat_calculator.rb
+++ b/lib/stat_calculator.rb
@@ -58,6 +58,24 @@ class StatCalculator
   end
 
   def least_accurate_team(season)
+    #return name of the Team with the best ratio of shots to goals for the given season
+    accuracy_by_team = teams_shot_ratios_by_season(season)
+    worst_team = nil
+    worst_average = 10000000000.00
+
+    #find team with the highest accuracy
+    accuracy_by_team.each do |team_id, average|
+      if average < worst_average 
+        worst_average = average
+        worst_team = team_id
+      end
+    end
+
+    #find team name by best_team ID
+    team = teams.find { |t| t.team_id.to_i == worst_team.to_i }
+
+    # Return the team name or nil if not found
+    team ? team.team_name : nil  
   end
 
   def game_ids_in_season(season)

--- a/lib/stat_calculator.rb
+++ b/lib/stat_calculator.rb
@@ -35,4 +35,29 @@ class StatCalculator
   def count_of_teams
     @teams.count
   end
+
+  def game_ids_in_season(season)
+    #filter games to get games for the specified season
+    game_ids = []
+    games.each do |game|
+      if game.season == season
+        game_ids << game.game_id
+      end
+    end
+    game_ids
+  end
+
+  def game_teams_in_season(season)
+    #extract game IDs from filtered games
+    game_ids = game_ids_in_season(season) #game ids from season
+    season_game_teams = []
+    @game_teams.each do |game_team|
+      #include game_team data only if its game_id is part of the season
+      if game_ids.include?(game_team.game_id) 
+        season_game_teams << game_team
+      end
+    end
+    season_game_teams 
+  end
+
 end

--- a/spec/stat_calculator_spec.rb
+++ b/spec/stat_calculator_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe StatCalculator do
   end
 
   describe '#least_accurate_team(season)' do
-    it 'returns name of most accurate team' do
+    xit 'returns name of most accurate team' do
       stats1 = @stat_calculator.least_accurate_team("20132014")
       expect(stats1).to eq("New York City FC")
       

--- a/spec/stat_calculator_spec.rb
+++ b/spec/stat_calculator_spec.rb
@@ -55,4 +55,30 @@ RSpec.describe StatCalculator do
     end
   end
 
+  describe '#teams_shot_ratios_by_season(season)' do
+    it 'filter teams in the specified season' do
+      stats = @stat_calculator.teams_shot_ratios_by_season("20122013")
+      expect(stats.count).to eq(30)
+    end
+  end
+
+  describe '#most_accurate_team(season)' do
+    it 'returns name of most accurate team' do
+      stats1 = @stat_calculator.most_accurate_team("20132014")
+      expect(stats1).to eq("Real Salt Lake")
+      
+      stats2 = @stat_calculator.most_accurate_team("20142015")
+      expect(stats2).to eq("Toronto FC")
+    end
+  end
+
+  describe '#least_accurate_team(season)' do
+    it 'returns name of most accurate team' do
+      stats1 = @stat_calculator.least_accurate_team("20132014")
+      expect(stats1).to eq("New York City FC")
+      
+      stats2 = @stat_calculator.least_accurate_team("20142015")
+      expect(stats2).to eq("Columbus Crew SC")
+    end
+  end
 end

--- a/spec/stat_calculator_spec.rb
+++ b/spec/stat_calculator_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe StatCalculator do
   end
 
   describe '#least_accurate_team(season)' do
-    xit 'returns name of most accurate team' do
+    it 'returns name of most accurate team' do
       stats1 = @stat_calculator.least_accurate_team("20132014")
       expect(stats1).to eq("New York City FC")
       

--- a/spec/stat_calculator_spec.rb
+++ b/spec/stat_calculator_spec.rb
@@ -42,4 +42,17 @@ RSpec.describe StatCalculator do
       expect(@stat_calculator.lowest_total_score).to eq(0)  
     end
   end
+
+  describe '#game_ids_in_season(season)' do
+    it 'filter games in the specified season' do
+      expect(@stat_calculator.game_ids_in_season("20122013").count).to eq(806)
+    end
+  end
+
+  describe '#game_teams_in_season(season)' do
+    it 'filter games_teams in the specified season' do
+      expect(@stat_calculator.game_teams_in_season("20122013").count).to eq(1612)
+    end
+  end
+
 end


### PR DESCRIPTION
This PR introduces adds new methods to the StatCalculator class: 

1. most_accurate_team(season) 
2. least_accurate_team(season)

These methods calculate the team with the highest and lowest accuracy (defined as the ratio of goals to shots) for a given season. Additional helper methods have been added to support them.

**Helper Methods**
- game_ids_in_season(season): Filters and returns the game_ids of all games in the specified season
- game_teams_in_season(season): Uses game_ids_in_season to find and return all game_team entries for the specified season
- teams_shot_ratios_by_season(season): Calculates the shot-to-goal accuracy ratio for each team in the specified season. Returns a hash where each key is a team_id and each value is the average accuracy for that team.
Code Refactoring and Clean-up

**Testing**
Added RSpec tests for most_accurate_team(season) and least_accurate_team(season), as well as tests for their helper methods.
